### PR TITLE
Actually store the signal handler id for the "need-data" signal

### DIFF
--- a/src/bin/test-player.rs
+++ b/src/bin/test-player.rs
@@ -1,5 +1,5 @@
-extern crate playground;
 extern crate ipc_channel;
+extern crate playground;
 
 use std::env;
 use std::error::Error;
@@ -56,10 +56,8 @@ fn main() {
                     println!("finished pushing data");
                     break;
                 }
-                Ok(size) => {
-                    if !p.push_data(Vec::from(&buffer[0..size])) {
-                        break;
-                    }
+                Ok(size) => if !p.push_data(Vec::from(&buffer[0..size])) {
+                    break;
                 },
                 Err(e) => {
                     eprintln!("Error: {}", e);

--- a/src/player.rs
+++ b/src/player.rs
@@ -386,7 +386,7 @@ impl Player {
 
                         let need_data_id = Arc::new(Mutex::new(None));
                         let need_data_id_clone = need_data_id.clone();
-                        appsrc.connect("need-data", false, move |args| {
+                        *need_data_id.lock().unwrap() = Some(appsrc.connect("need-data", false, move |args| {
                             let _ = sender_clone.lock().unwrap().send(Ok(()));
                             if let Some(id) = need_data_id_clone.lock().unwrap().take() {
                                 glib::signal::signal_handler_disconnect(
@@ -395,7 +395,7 @@ impl Player {
                                 );
                             }
                             None
-                        }).unwrap();
+                        }).unwrap());
 
                         inner.set_app_src(appsrc);
                     } else {


### PR DESCRIPTION
Seems to have disappeared during refactoring at some point